### PR TITLE
Breadcrumb Builder Utility

### DIFF
--- a/KeyMgr/app/View/Components/Breadcrumb.php
+++ b/KeyMgr/app/View/Components/Breadcrumb.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @author Zachary Abela-Gale <abel1325@pacificu.edu>
+ */
+namespace App\View\Components;
+
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class Breadcrumb extends Component
+{
+  /**
+   * Create a new component instance.
+   */
+  public function __construct(public mixed $crumbs)
+  {
+    // crumbs should be an array of dictionaries. 
+    // Each dictionary should have a 'text' and 'link' key. 
+    // The 'link' key may be null.
+  }
+
+  /**
+   * Get the view / contents that represent the component.
+   */
+  public function render(): View|Closure|string
+  {
+    return view('components.breadcrumb');
+  }
+}

--- a/KeyMgr/resources/views/campus/campusList.blade.php
+++ b/KeyMgr/resources/views/campus/campusList.blade.php
@@ -2,15 +2,30 @@
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 @section('title', __('Campuses'))
 
-@section ("content")
+
+@php
+$crumbs=[
+  ['link' => '/locations', 'text' => 'Locations'],
+  ['link' => '/campus', 'text' => 'Campuses'],
+];
+@endphp
+
 @section('content_header')
+<div class="row mb-2">
+  <div class="col-sm-6">
     <h1>List of Campuses</h1>
-    <div class="col text-right">
+    </div>
+    <div class="col-sm-6">
+    <x-breadcrumb :crumbs="$crumbs"></x-breadcrumb>
+    </div>
+</div>
+<div class="col text-right">
       <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#campusForm">
         New Campus
       </button>
-      </div>  
+    </div>  
 @stop
+@section ("content")
 @section('plugins.Datatables', true)
 
 @include('campus.partials.newCampusModal')

--- a/KeyMgr/resources/views/components/breadcrumb.blade.php
+++ b/KeyMgr/resources/views/components/breadcrumb.blade.php
@@ -1,0 +1,23 @@
+@php
+  /**
+   * @author Zachary Abela-Gale <abel1325@pacificu.edu>
+   */
+
+  $lastElement = array_key_last($crumbs);
+@endphp
+
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb float-sm-right">
+    @foreach ($crumbs as $key => $crumb)
+      @if($key === $lastElement)
+        <li class="breadcrumb-item active" aria-current="page">
+          <a href="{{$crumb['link']}}">{{$crumb['text']}}</a>
+        </li>
+      @else
+        <li class="breadcrumb-item">
+          <a href="{{$crumb['link']}}">{{$crumb['text']}}</a>
+        </li>
+      @endif
+    @endforeach
+  </ol>
+</nav>


### PR DESCRIPTION
Instead of manually implementing [Bootstrap breadcrumbs](https://getbootstrap.com/docs/4.0/components/breadcrumb/) we can now use a component, `x-breadcrumb` to create them.

Sample usage:
```
// Define the crumbs in either the controller or blade.
$crumbs = [
  [
    'link' => '/locations', 
    'text'=>'Locations'
  ],
  [
    'link' => '/campus',
    'text' => 'Campuses'
  ]
]

// Use component
<x-breadcrumb :crumbs="$crumbs"></x-breadcrumb>
```
\*Ideally the `route()` functionality would be used instead of hardcoded routes.